### PR TITLE
Error handler

### DIFF
--- a/ApplicationEvents.vb
+++ b/ApplicationEvents.vb
@@ -1,0 +1,21 @@
+Namespace My
+
+    ' Los siguientes eventos están disponibles para MyApplication:
+    ' 
+    ' Inicio: se desencadena cuando se inicia la aplicación, antes de que se cree el formulario de inicio.
+    ' Apagado: generado después de cerrar todos los formularios de la aplicación. Este evento no se genera si la aplicación termina de forma anómala.
+    ' UnhandledException: generado si la aplicación detecta una excepción no controlada.
+    ' StartupNextInstance: se desencadena cuando se inicia una aplicación de instancia única y la aplicación ya está activa. 
+    ' NetworkAvailabilityChanged: se desencadena cuando la conexión de red está conectada o desconectada.
+    Partial Friend Class MyApplication
+
+        Private Sub MyApplication_UnhandledException(ByVal sender As Object, ByVal e As Microsoft.VisualBasic.ApplicationServices.UnhandledExceptionEventArgs) Handles Me.UnhandledException
+
+            My.Application.Log.WriteException(e.Exception, TraceEventType.Critical, _
+    "Se cerró la aplicación a las ...:" & My.Computer.Clock.GmtTime.ToString & " error app events")
+
+        End Sub
+    End Class
+
+End Namespace
+

--- a/Imprime.vbproj
+++ b/Imprime.vbproj
@@ -54,6 +54,7 @@
     <Import Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationEvents.vb" />
     <Compile Include="controllers\ControladorAvisoSonoro.vb" />
     <Compile Include="controllers\ControladorCapturaDeImagenes.vb" />
     <Compile Include="controllers\ControladorImpresora.vb" />
@@ -105,6 +106,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="My Project\Application.myapp">
       <Generator>MyApplicationCodeGenerator</Generator>
       <LastGenOutput>Application.Designer.vb</LastGenOutput>

--- a/app.config
+++ b/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <system.diagnostics>
+        <sources>
+            <!-- En esta sección se define la configuración del registro para My.Application.Log -->
+            <source name="DefaultSource" switchName="DefaultSwitch">
+                <listeners>
+                    <add name="FileLog"/>
+                    <!-- Quite los comentarios de la sección posterior para escribir en el registro de eventos de la aplicación -->
+                    <!--<add name="EventLog"/>-->
+                </listeners>
+            </source>
+        </sources>
+        <switches>
+            <add name="DefaultSwitch" value="Information" />
+        </switches>
+      
+        <sharedListeners>
+            <add name="FileLog"
+                 type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" 
+                 initializeData="Cedir" 
+                  />
+            <!-- Quite los comentarios de la sección posterior y reemplace APPLICATION_NAME con el nombre de su aplicación para escribir en el registro de sucesos de la aplicación -->
+            <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
+        </sharedListeners>
+    </system.diagnostics>
+</configuration>

--- a/controllers/ControladorCapturaDeImagenes.vb
+++ b/controllers/ControladorCapturaDeImagenes.vb
@@ -15,7 +15,7 @@ Public Class ControladorCapturaDeImagenes
         Catch ex As Exception
             'loguear por que no se recupero del error
             Dim err As New errorHandler
-            err.logError(ex)
+            err.logError(ex, "Error en ControladorImagenes, metodo guardarCapturaEnDisco " & Me.ToString())
             Return False
         End Try
     End Function

--- a/controllers/ControladorCapturaDeImagenes.vb
+++ b/controllers/ControladorCapturaDeImagenes.vb
@@ -14,7 +14,8 @@ Public Class ControladorCapturaDeImagenes
             reporte.guardar()
         Catch ex As Exception
             'loguear por que no se recupero del error
-            MessageBox.Show(ex.Message)
+            Dim err As New errorHandler
+            err.logError(ex)
             Return False
         End Try
     End Function

--- a/controllers/ControladorImpresora.vb
+++ b/controllers/ControladorImpresora.vb
@@ -1,6 +1,7 @@
 Public Class ControladorImpresora
 
-    Public Sub imprimirImagenes(ByVal reporte As Reporte)
+    Public Function imprimirImagenes(ByVal reporte As Reporte) As Boolean
+
 
         Dim rp As New report
         Try
@@ -10,11 +11,13 @@ Public Class ControladorImpresora
             rp.PrintToPrinter(1, False, 0, 0)
         Catch ex As Exception
             'error de nombre de archivo
-            MessageBox.Show("no se ha podido imprimir, debido a que la imagen no fue guardada.")
+            Dim err As New errorHandler
+            err.logError(ex, Me.ToString)
+            Return False
         Finally
             rp = Nothing
         End Try
 
 
-    End Sub
+    End Function
 End Class

--- a/controllers/errorHandler.vb
+++ b/controllers/errorHandler.vb
@@ -15,11 +15,7 @@ Public Class errorHandler
         End Set
     End Property
 
-    Public Function logError(ByVal ex As Exception) As String
-        Return ex.Message
-    End Function
-
-    Private Sub catchErrorToFile()
+    Public Sub logError(ByVal ex As Exception)
         Dim path As String = "c:\ErrorCapturaImagenes.txt"
 
         Using sw As StreamWriter = New StreamWriter(path, True)
@@ -35,5 +31,7 @@ Public Class errorHandler
 
 
     End Sub
+
+   
 
 End Class

--- a/controllers/errorHandler.vb
+++ b/controllers/errorHandler.vb
@@ -4,34 +4,26 @@ Imports System.Text
 
 
 Public Class errorHandler
+    Const path As String = "c:\ErrorCapturaImagenes.txt"
 
-    Private m_ex As Exception
-    Public Property ex() As Exception
-        Get
-            Return m_ex
-        End Get
-        Set(ByVal value As Exception)
-            m_ex = value
-        End Set
-    End Property
-
-    Public Sub logError(ByVal ex As Exception)
-        Dim path As String = "c:\ErrorCapturaImagenes.txt"
+    Public Sub logError(ByVal exeption As Exception, Optional ByVal mensajesAdicionales As String = "")
 
         Using sw As StreamWriter = New StreamWriter(path, True)
             sw.WriteLine("-------------------")
             sw.Write("Fecha ...: ")
             sw.WriteLine(DateTime.Now)
             sw.Write("Mensaje de error ...: ")
-            sw.WriteLine(ex.Message())
+            sw.WriteLine(exeption.Message())
+            If mensajesAdicionales <> "" Then
+                sw.Write("Mensajes adicionales.: ")
+                sw.WriteLine(mensajesAdicionales)
+            End If
             sw.WriteLine("-------------------")
             sw.Close()
 
         End Using
-
-
     End Sub
 
-   
-
+    Public Sub New()
+    End Sub
 End Class

--- a/models/Reporte.vb
+++ b/models/Reporte.vb
@@ -33,7 +33,7 @@ Public Class Reporte
         fecha = fecha.Replace("/", "-")
         fecha = fecha.Replace(":", "-")
 
-        m_pathLocation = "d:\" + fecha + "\"
+        m_pathLocation = "z:\" + fecha + "\" 'prueba de directorio inexistente
 
     End Sub
     Public Function guardar() As Boolean

--- a/models/Reporte.vb
+++ b/models/Reporte.vb
@@ -33,7 +33,7 @@ Public Class Reporte
         fecha = fecha.Replace("/", "-")
         fecha = fecha.Replace(":", "-")
 
-        m_pathLocation = "z:\" + fecha + "\" 'prueba de directorio inexistente
+        m_pathLocation = "c:\" + fecha + "\" 'prueba de directorio inexistente
 
     End Sub
     Public Function guardar() As Boolean
@@ -49,9 +49,8 @@ Public Class Reporte
 
         Catch ex As Exception
             'logueo del error de escritura en disco
-            Dim eH As New errorHandler
-            eH.logError(ex)
-
+            Dim err As New errorHandler
+            err.logError(ex, Me.ToString)
             Return False
         End Try
 


### PR DESCRIPTION
@walterbrunetti 
Waly, estuve probando los metodos de .net para hacer trace de los errores. Pero si bien el framework tiene metodos para seguir los errores, no funcionan algunas cosas de logueo. Entre otras, no se puede cambiar el path del archivo de logueo. 

. Tampoco se crea un solo archivo de log
Segun lo que vi en el la web, esto se corrigió en las posteriores releases del framework . 

Comentame y saludos
